### PR TITLE
将玩家离开和断连的情况分开处理

### DIFF
--- a/src/main/java/pvp_in_the_spire/patches/steamConnect/SteamManager.java
+++ b/src/main/java/pvp_in_the_spire/patches/steamConnect/SteamManager.java
@@ -111,7 +111,7 @@ public class SteamManager {
     {
         try
         {
-            steamNetworking.sendP2PPacket(id,fromBuffer, SteamNetworking.P2PSend.Reliable,STEAM_CHANNEL);
+            steamNetworking.sendP2PPacket(id,fromBuffer, SteamNetworking.P2PSend.ReliableWithBuffering,STEAM_CHANNEL);
         }
         catch (SteamException e)
         {

--- a/src/main/java/pvp_in_the_spire/ui/ConfigPageModules/MultiplayerConfigPage.java
+++ b/src/main/java/pvp_in_the_spire/ui/ConfigPageModules/MultiplayerConfigPage.java
@@ -370,8 +370,14 @@ this,this.toggleOptionList.size());
     //处理房间人员变化的回调
     @Override
     public void onMemberChanged(SteamID personId, SteamMatchmaking.ChatMemberStateChange memberStage) {
+        if (memberStage == SteamMatchmaking.ChatMemberStateChange.Entered) {
+            //在通信内容里面注册这个玩家
+            LobbyChatServer.instance.registerPlayer(personId);
+        } else if (memberStage == SteamMatchmaking.ChatMemberStateChange.Disconnected)
+        // 如果只是断连了，那就不管，靠steamNetwork自己重连
+        {
+        } else
         //如果是有玩家退出了，就移交房主
-        if(memberStage != SteamMatchmaking.ChatMemberStateChange.Entered)
         {
             //回退到刚加入房间的状态
             this.initNetworkStage(LobbyManager.amIOwner(),this.closePageEvent);
@@ -381,10 +387,6 @@ this,this.toggleOptionList.size());
             resetReadyButton();
             //移除该玩家
             GlobalManager.playerManager.onPlayerLeave(personId.getAccountID());
-        }
-        else {
-            //在通信内容里面注册这个玩家
-            LobbyChatServer.instance.registerPlayer(personId);
         }
     }
 


### PR DESCRIPTION
ping超时或其他触发断连的情形下，网络恢复正常后双方都可以正常收发信息，这是steamNetwork的重连功能。
其他玩家只是断开连接时不应该按离开处理（强制本地玩家退出）